### PR TITLE
Fix typo in comment

### DIFF
--- a/lua/swapdiff/init.lua
+++ b/lua/swapdiff/init.lua
@@ -65,7 +65,7 @@ local _log = Logger:empty()
 ---@type table<string, PrimaryBufferHandler>
 local _buffer_handlers = {}
 
----@param filepath string asbolute filepath
+---@param filepath string absolute filepath
 ---@return SwapDiffSwapInfo[]
 local function get_swapinfos(filepath)
   local swapfiles = fn.swapfilelist()


### PR DESCRIPTION
## Summary
- fix a typo in `get_swapinfos` parameter comment

## Testing
- `sh test.sh` *(fails: `nvim` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442b82794c832e9adbee7721acdb1f